### PR TITLE
Compressed topics

### DIFF
--- a/lib/ui/widgets/bill_list_item.dart
+++ b/lib/ui/widgets/bill_list_item.dart
@@ -84,6 +84,7 @@ class _BillListItemState extends State<BillListItem> {
                 TopicsWidget(
                   topics: widget.billData.topics,
                   canPress: false,
+                  compressed: true,
                 ),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/ui/widgets/topics_widget.dart
+++ b/lib/ui/widgets/topics_widget.dart
@@ -117,7 +117,7 @@ class _TopicsButtonWidgetState extends State<TopicsButtonWidget> {
   }
 
   Widget build(BuildContext context) {
-    Widget TopicButton = RaisedButton.icon(
+    return widget.compressed ? _tagToIcon(widget.topic) : RaisedButton.icon(
       splashColor: Theme.of(context).colorScheme.primary,
       color: widget.hasFill ? Color.fromRGBO(0, 0, 0, 0.6) : Colors.transparent,
       highlightElevation: 0,
@@ -151,8 +151,6 @@ class _TopicsButtonWidgetState extends State<TopicsButtonWidget> {
         ),
       ),
     );
-
-    return widget.compressed == false ? TopicButton : _tagToIcon(widget.topic);
   }
 }
 

--- a/lib/ui/widgets/topics_widget.dart
+++ b/lib/ui/widgets/topics_widget.dart
@@ -7,6 +7,7 @@ class TopicsWidget extends StatelessWidget {
   final List<String> topics;
   final bool canPress;
   final bool hasFill;
+  final bool compressed;
 
   /// To convert tags to topics and display them
   ///
@@ -14,17 +15,23 @@ class TopicsWidget extends StatelessWidget {
   /// usage:
   ///
   /// `child: TopicsWidget(topics: topics),`
-  TopicsWidget({Key /*?*/ key, @required this.topics, @required this.canPress, this.hasFill = false})
+  TopicsWidget(
+      {Key /*?*/ key,
+      @required this.topics,
+      @required this.canPress,
+      this.hasFill = false,
+      this.compressed = false})
       : super(key: key);
 
-  List<Widget> _buildTopicList(
-      List<String> billTopics, BuildContext context, bool canPress) {
+  List<Widget> _buildTopicList(List<String> billTopics, BuildContext context,
+      bool canPress, bool compressed) {
     List<Widget> topics = new List();
     billTopics.forEach((item) {
       topics.add(TopicsButtonWidget(
         topic: item,
         canPress: canPress,
-        hasFill: hasFill
+        hasFill: hasFill,
+        compressed: compressed,
       ));
     });
     return topics;
@@ -33,10 +40,17 @@ class TopicsWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return topics != null
-        ? Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: _buildTopicList(topics, context, canPress),
-          )
+        ? compressed == false
+            ? Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children:
+                    _buildTopicList(topics, context, canPress, compressed),
+              )
+            : Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children:
+                    _buildTopicList(topics, context, canPress, compressed),
+              )
         : Padding(
             padding: EdgeInsets.only(bottom: 0, top: 0),
           );
@@ -47,8 +61,14 @@ class TopicsButtonWidget extends StatefulWidget {
   final String topic;
   final bool canPress;
   final bool hasFill;
+  final bool compressed;
 
-  TopicsButtonWidget({Key key, @required this.topic, @required this.canPress, this.hasFill = false})
+  TopicsButtonWidget(
+      {Key key,
+      @required this.topic,
+      @required this.canPress,
+      this.hasFill = false,
+      this.compressed = false})
       : super(key: key);
 
   @override
@@ -58,6 +78,7 @@ class TopicsButtonWidget extends StatefulWidget {
 class _TopicsButtonWidgetState extends State<TopicsButtonWidget> {
   final Box<List> userTags = Hive.box<List>(HIVE_USER_PREFS_LIST);
   bool _active = false;
+
   void _updateTagPreferences(String item) {
     List<String> blankTags = [];
     List<String> finalTags = [];
@@ -96,7 +117,7 @@ class _TopicsButtonWidgetState extends State<TopicsButtonWidget> {
   }
 
   Widget build(BuildContext context) {
-    return RaisedButton.icon(
+    Widget TopicButton = RaisedButton.icon(
       splashColor: Theme.of(context).colorScheme.primary,
       color: widget.hasFill ? Color.fromRGBO(0, 0, 0, 0.6) : Colors.transparent,
       highlightElevation: 0,
@@ -105,17 +126,17 @@ class _TopicsButtonWidgetState extends State<TopicsButtonWidget> {
           ? Theme.of(context).colorScheme.primary
           : Theme.of(context).colorScheme.onSecondary,
       shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(5.0),
-        side: BorderSide(color: _active
-          ? Theme.of(context).colorScheme.primary
-          : Theme.of(context).colorScheme.onSecondary,
-          width: 1.5
-        )
-      ),
+          borderRadius: BorderRadius.circular(5.0),
+          side: BorderSide(
+              color: _active
+                  ? Theme.of(context).colorScheme.primary
+                  : Theme.of(context).colorScheme.onSecondary,
+              width: 1.5)),
       onPressed: widget.canPress
-        ? () {
-          _updateTagPreferences(widget.topic);
-        } : null,
+          ? () {
+              _updateTagPreferences(widget.topic);
+            }
+          : null,
       icon: _tagToIcon(widget.topic),
       label: Text(
         widget.topic,
@@ -125,11 +146,13 @@ class _TopicsButtonWidgetState extends State<TopicsButtonWidget> {
           color: _active
               ? Theme.of(context).colorScheme.primary
               : widget.hasFill
-                ? Colors.white
-                : Theme.of(context).colorScheme.onSurface,
+                  ? Colors.white
+                  : Theme.of(context).colorScheme.onSurface,
         ),
       ),
     );
+
+    return widget.compressed == false ? TopicButton : _tagToIcon(widget.topic);
   }
 }
 


### PR DESCRIPTION
**Problem:**
The TopicsWidget in the BillListItem takes up too much space

**Solution:**
Add logic and a boolean opperator to allow a smaller version (Row) of the TopicsWidget

Usage:

```dart
                TopicsWidget(
                  topics: widget.billData.topics,
                  canPress: false,
                  compressed: true,
                ),
```

![Screenshot from 2021-01-24 12-11-18](https://user-images.githubusercontent.com/7298449/105618602-4cd55f00-5e3d-11eb-9cdc-b0017575ecff.png)
