### PR TITLE
Bills with long summary have a read more toggle

### DIFF
--- a/lib/ui/views/bills/bill_view.dart
+++ b/lib/ui/views/bills/bill_view.dart
@@ -7,11 +7,9 @@ import 'package:voting_app/core/models/bill.dart';
 import 'package:voting_app/core/models/block_chain_data.dart';
 import 'package:voting_app/core/viewmodels/bill_model.dart';
 import 'package:voting_app/locator.dart';
-import 'package:voting_app/ui/styles.dart';
 import 'package:voting_app/ui/views/base_view.dart';
 import 'package:voting_app/ui/views/bills/pdf_viewer.dart';
-import 'package:voting_app/ui/widgets/house_icon_widget.dart';
-import 'package:voting_app/ui/widgets/pie_chart.dart';
+import 'package:voting_app/ui/widgets/read_more_text.dart';
 import 'package:voting_app/ui/widgets/topics_widget.dart';
 import 'package:voting_app/ui/widgets/user_voted_status_widget.dart';
 import 'package:voting_app/ui/widgets/voting_status_widget.dart';
@@ -83,188 +81,183 @@ class _BillPageState extends State<BillPage> {
       builder: (context, model, child) => Scaffold(
         appBar: AppBar(
           iconTheme:
-              IconThemeData(color: Theme.of(context).colorScheme.onSurface),
+            IconThemeData(color: Theme.of(context).colorScheme.onSurface),
           backgroundColor: Theme.of(context).backgroundColor,
           elevation: 0,
           title: Text('Back',
-              style: TextStyle(
-                  color: Theme.of(context).colorScheme.onSurface,
-                  fontSize: 14)),
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurface,
+              fontSize: 14)
+          )
         ),
         body: model.state == ViewState.Busy
-            ? Center(child: CircularProgressIndicator())
-            : Center(
-                child: Container(
-                  margin: EdgeInsets.only(left: 14.0, right: 14.0),
-                  child: ListView(
-                    children: <Widget>[
-                      Card(
-                        margin: EdgeInsets.all(4.0),
-                        child: Align(
-                          child: Padding(
-                            padding: EdgeInsets.all(20.0),
-                            child: Text(widget.bill.shortTitle.replaceAll(new RegExp(r"[^\s\w()]"), ""),
-                                style: Theme.of(context).textTheme.headline5),
-                          ),
-                          alignment: Alignment.centerLeft,
-                        ),
-                      ),
-                      Container(
-                        padding: EdgeInsets.only(top: 14.0, bottom: 14.0),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          crossAxisAlignment: CrossAxisAlignment.center,
-                          children: <Widget>[
-                            WatchBillWidget(id: widget.bill.id),
-                            VotingStatusWidget(
-                                bill: widget.bill,
-                                voted: _vote != null ? true : false,
-                                size: 20),
-                            UserVotedStatus(
-                                bill: widget.bill,
-                                voted: _vote != null ? true : false,
-                                size: 20)
-                          ],
-                        ),
-                      ),
-                      Container(
-                        child: Column(
-                          children: <Widget>[
-                            Align(
-                              child: Padding(
-                                padding:
-                                    EdgeInsets.only(bottom: 10.0, top: 10.0),
-                                child: Text('About this bill',
-                                    style:
-                                        Theme.of(context).textTheme.headline6),
-                              ),
-                              alignment: Alignment.centerLeft,
-                            ),
-                            Padding(
-                              padding: EdgeInsets.only(bottom: 20.0),
-                              child: Text(
-                                widget.bill.summary,
-                                style: Theme.of(context).textTheme.bodyText2,
-                              ),
-                            ),
-                            Align(
-                              child: Padding(
-                                padding:
-                                    EdgeInsets.only(bottom: 10.0, top: 20.0),
-                                child: Text('Tags',
-                                    style:
-                                        Theme.of(context).textTheme.headline6),
-                              ),
-                              alignment: Alignment.centerLeft,
-                            ),
-                            TopicsWidget(
-                              topics: widget.bill.topics,
-                              canPress: false,
-                            ),
-                            Align(
-                              child: Padding(
-                                padding:
-                                    EdgeInsets.only(bottom: 10.0, top: 20.0),
-                                child: Text('More info',
-                                    style:
-                                        Theme.of(context).textTheme.headline6),
-                              ),
-                              alignment: Alignment.centerLeft,
-                            ),
-                            RaisedButton(
-                              padding: EdgeInsets.only(
-                                  bottom: 8.0,
-                                  top: 8.0,
-                                  left: 10.0,
-                                  right: 10.0),
-                              onPressed: () {
-                                launch(widget.bill.textLinkHtml);
-
-//                                Navigator.push(
-//                                  context,
-//                                  MaterialPageRoute<PdfPage>(
-//                                      builder: (context) => PdfPage(
-//                                          pdfUrl: widget.bill.textLinkPdf)),
-//                                );
-                              },
-                              color: Color(0xff898989),
-                              child: Padding(
-                                padding: EdgeInsets.all(6.0),
-                                child: Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: <Widget>[
-                                    Text(
-                                      'View Bill Text',
-                                    ),
-                                    Icon(
-                                      Icons.arrow_right_alt,
-                                      color: Colors.white,
-                                    )
-                                  ],
-                                ),
-                              ),
-                            ),
-                            Container(
-                              padding: EdgeInsets.only(bottom: 10.0, top: 20.0),
-                              child: Text(
-                                "Text of the bill as introduced into the Parliament",
-                                style: Theme.of(context).textTheme.bodyText2,
-                              ),
-                            ),
-                            RaisedButton(
-                              padding: EdgeInsets.only(
-                                  bottom: 8.0,
-                                  top: 8.0,
-                                  left: 10.0,
-                                  right: 10.0),
-                              onPressed: () {
-                                launch(widget.bill.emLinkHtml);
-//                                Navigator.push(
-//                                  context,
-//                                  MaterialPageRoute<PdfPage>(
-//                                      builder: (context) => PdfPage(
-//                                          pdfUrl: widget.bill.emLinkPdf)),
-//                                );
-                              },
-                              color: Color(0xff898989),
-                              child: Padding(
-                                padding: EdgeInsets.all(6.0),
-                                child: Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: <Widget>[
-                                    Text(
-                                      'View Explanatory Memoranda',
-                                    ),
-                                    Icon(
-                                      Icons.arrow_right_alt,
-                                      color: Colors.white,
-                                    )
-                                  ],
-                                ),
-                              ),
-                            ),
-                            Container(
-                              padding: EdgeInsets.only(bottom: 10.0, top: 20.0),
-                              child: Text(
-                                "Accompanies and provides an explanation of the content of the introduced version (first reading) of the bill.",
-                                style: Theme.of(context).textTheme.bodyText2,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                      VoteWidget(
-                          data: completeBlockChainData.toBillChainData(),
-                          vote: model.getVote,
-                          yes: model.billVoteResult.yes,
-                          no: model.billVoteResult.no,
-                          shortDescription: widget.bill.shortTitle),
-                    ],
+        ? Center(child: CircularProgressIndicator())
+        : Center(child: Container(
+          margin: EdgeInsets.only(left: 14.0, right: 14.0),
+          child: ListView(
+            children: <Widget>[
+              Card(
+                margin: EdgeInsets.all(4.0),
+                child: Align(
+                  child: Padding(
+                    padding: EdgeInsets.all(20.0),
+                    child: Text(widget.bill.shortTitle.replaceAll(new RegExp(r"[^\s\w()]"), ""),
+                        style: Theme.of(context).textTheme.headline5),
                   ),
+                  alignment: Alignment.centerLeft,
                 ),
               ),
+              Container(
+                padding: EdgeInsets.only(top: 14.0, bottom: 14.0),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: <Widget>[
+                    WatchBillWidget(id: widget.bill.id),
+                    VotingStatusWidget(
+                        bill: widget.bill,
+                        voted: _vote != null ? true : false,
+                        size: 20),
+                    UserVotedStatus(
+                        bill: widget.bill,
+                        voted: _vote != null ? true : false,
+                        size: 20)
+                  ],
+                ),
+              ),
+              Container(
+                child: Column(
+                  children: <Widget>[
+                    if (widget.bill.summary != "") ...[
+                      Align(
+                        child: Padding(
+                          padding: EdgeInsets.only(bottom: 10.0, top: 10.0),
+                          child: Text('About this bill',
+                            style: Theme.of(context).textTheme.headline6
+                          ),
+                        ),
+                        alignment: Alignment.centerLeft,
+                      ),
+                      Padding(
+                        padding: EdgeInsets.only(bottom: 20.0),
+                        child: ReadMoreText(widget.bill.summary)
+                      )
+                    ],
+                    Align(
+                      child: Padding(
+                        padding: EdgeInsets.only(bottom: 10.0, top: 20.0),
+                        child: Text('Tags',
+                          style: Theme.of(context).textTheme.headline6
+                        ),
+                      ),
+                      alignment: Alignment.centerLeft,
+                    ),
+                    TopicsWidget(
+                      topics: widget.bill.topics,
+                      canPress: false,
+                    ),
+                    Align(
+                      child: Padding(
+                        padding: EdgeInsets.only(bottom: 10.0, top: 20.0),
+                        child: Text('More info',
+                          style: Theme.of(context).textTheme.headline6
+                        ),
+                      ),
+                      alignment: Alignment.centerLeft,
+                    ),
+                    RaisedButton(
+                      padding: EdgeInsets.only(
+                          bottom: 8.0,
+                          top: 8.0,
+                          left: 10.0,
+                          right: 10.0),
+                      onPressed: () {
+                        launch(widget.bill.textLinkHtml);
+                        // Navigator.push(
+                        //   context,
+                        //   MaterialPageRoute<PdfPage>(
+                        //     builder: (context) => PdfPage(
+                        //       pdfUrl: widget.bill.textLinkPdf)
+                        //   )
+                        // );
+                      },
+                      color: Color(0xff898989),
+                      child: Padding(
+                        padding: EdgeInsets.all(6.0),
+                        child: Row(
+                          mainAxisAlignment:
+                            MainAxisAlignment.spaceBetween,
+                          children: <Widget>[
+                            Text(
+                              'View Bill Text',
+                            ),
+                            Icon(
+                              Icons.arrow_right_alt,
+                              color: Colors.white,
+                            )
+                          ],
+                        ),
+                      ),
+                    ),
+                    Container(
+                      padding: EdgeInsets.only(bottom: 10.0, top: 20.0),
+                      child: Text(
+                        "Text of the bill as introduced into the Parliament",
+                        style: Theme.of(context).textTheme.bodyText2,
+                      ),
+                    ),
+                    RaisedButton(
+                      padding: EdgeInsets.only(
+                          bottom: 8.0,
+                          top: 8.0,
+                          left: 10.0,
+                          right: 10.0),
+                      onPressed: () {
+                        launch(widget.bill.emLinkHtml);
+                        // Navigator.push(
+                        //   context,
+                        //   MaterialPageRoute<PdfPage>(
+                        //     builder: (context) => PdfPage(
+                        //     pdfUrl: widget.bill.emLinkPdf)
+                        //   )
+                        // );
+                      },
+                      color: Color(0xff898989),
+                      child: Padding(
+                        padding: EdgeInsets.all(6.0),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: <Widget>[
+                            Text(
+                              'View Explanatory Memoranda',
+                            ),
+                            Icon(
+                              Icons.arrow_right_alt,
+                              color: Colors.white,
+                            )
+                          ],
+                        ),
+                      ),
+                    ),
+                    Container(
+                      padding: EdgeInsets.only(bottom: 10.0, top: 20.0),
+                      child: Text(
+                        "Accompanies and provides an explanation of the content of the introduced version (first reading) of the bill.",
+                        style: Theme.of(context).textTheme.bodyText2,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              VoteWidget(
+                data: completeBlockChainData.toBillChainData(),
+                vote: model.getVote,
+                yes: model.billVoteResult.yes,
+                no: model.billVoteResult.no,
+                shortDescription: widget.bill.shortTitle),
+            ],
+          ),
+        )),
       ),
     );
   }

--- a/lib/ui/widgets/read_more_text.dart
+++ b/lib/ui/widgets/read_more_text.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+// Found from https://www.developerlibs.com/2019/07/flutter-text-read-more-expand-feature.html
+
+enum TrimMode {
+  Length,
+  Line,
+}
+
+class ReadMoreText extends StatefulWidget {
+  const ReadMoreText(
+    this.data, {
+      Key key,
+      this.trimExpandedText = ' read less',
+      this.trimCollapsedText = ' ...read more',
+      this.colorClickableText,
+      this.trimLength = 240,
+      this.trimLines = 2,
+      this.trimMode = TrimMode.Length,
+      this.style,
+      this.textAlign,
+      this.textDirection,
+      this.locale,
+      this.textScaleFactor,
+      this.semanticsLabel,
+    })  : assert(data != null),
+          super(key: key);
+
+  final String data;
+  final String trimExpandedText;
+  final String trimCollapsedText;
+  final Color colorClickableText;
+  final int trimLength;
+  final int trimLines;
+  final TrimMode trimMode;
+  final TextStyle style;
+  final TextAlign textAlign;
+  final TextDirection textDirection;
+  final Locale locale;
+  final double textScaleFactor;
+  final String semanticsLabel;
+
+  @override
+  ReadMoreTextState createState() => ReadMoreTextState();
+}
+
+const String _kEllipsis = '\u2026';
+
+const String _kLineSeparator = '\u2028';
+
+class ReadMoreTextState extends State<ReadMoreText> {
+  bool _readMore = true;
+
+  void _onTapLink() {
+    setState(() => _readMore = !_readMore);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final DefaultTextStyle defaultTextStyle = DefaultTextStyle.of(context);
+    TextStyle effectiveTextStyle = widget.style;
+    if (widget.style == null || widget.style.inherit) {
+      effectiveTextStyle = defaultTextStyle.style.merge(widget.style);
+    }
+
+    final textAlign =
+        widget.textAlign ?? defaultTextStyle.textAlign ?? TextAlign.start;
+    final textDirection = widget.textDirection ?? Directionality.of(context);
+    final textScaleFactor =
+        widget.textScaleFactor ?? MediaQuery.textScaleFactorOf(context);
+    final overflow = defaultTextStyle.overflow;
+    final locale =
+        widget.locale ?? Localizations.localeOf(context, nullOk: true);
+
+    final colorClickableText =
+        widget.colorClickableText ?? Theme.of(context).accentColor;
+
+    TextSpan link = TextSpan(
+      text: _readMore ? widget.trimCollapsedText : widget.trimExpandedText,
+      style: effectiveTextStyle.copyWith(
+        color: colorClickableText,
+      ),
+      recognizer: TapGestureRecognizer()..onTap = _onTapLink,
+    );
+
+    Widget result = LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        assert(constraints.hasBoundedWidth);
+        final double maxWidth = constraints.maxWidth;
+
+        // Create a TextSpan with data
+        final text = TextSpan(
+          style: effectiveTextStyle,
+          text: widget.data,
+        );
+
+        // Layout and measure link
+        TextPainter textPainter = TextPainter(
+          text: link,
+          textAlign: textAlign,
+          textDirection: textDirection,
+          textScaleFactor: textScaleFactor,
+          maxLines: widget.trimLines,
+          ellipsis: overflow == TextOverflow.ellipsis ? _kEllipsis : null,
+          locale: locale,
+        );
+        textPainter.layout(minWidth: constraints.minWidth, maxWidth: maxWidth);
+        final linkSize = textPainter.size;
+
+        // Layout and measure text
+        textPainter.text = text;
+        textPainter.layout(minWidth: constraints.minWidth, maxWidth: maxWidth);
+        final textSize = textPainter.size;
+
+        print('linkSize $linkSize textSize $textSize');
+
+        // Get the endIndex of data
+        bool linkLongerThanLine = false;
+        int endIndex;
+
+        if (linkSize.width < maxWidth) {
+          final pos = textPainter.getPositionForOffset(Offset(
+            textSize.width - linkSize.width,
+            textSize.height,
+          ));
+          endIndex = textPainter.getOffsetBefore(pos.offset);
+        }
+        else {
+          var pos = textPainter.getPositionForOffset(
+            textSize.bottomLeft(Offset.zero),
+          );
+          endIndex = pos.offset;
+          linkLongerThanLine = true;
+        }
+
+        TextSpan textSpan;
+        switch (widget.trimMode) {
+          case TrimMode.Length:
+            if (widget.trimLength < widget.data.length) {
+              textSpan = TextSpan(
+                style: effectiveTextStyle,
+                text: _readMore
+                    ? widget.data.substring(0, widget.trimLength)
+                    : widget.data,
+                children: <TextSpan>[link],
+              );
+            } else {
+              textSpan = TextSpan(
+                style: effectiveTextStyle,
+                text: widget.data,
+              );
+            }
+            break;
+          case TrimMode.Line:
+            if (textPainter.didExceedMaxLines) {
+              textSpan = TextSpan(
+                style: effectiveTextStyle,
+                text: _readMore
+                    ? widget.data.substring(0, endIndex) +
+                    (linkLongerThanLine ? _kLineSeparator : '')
+                    : widget.data,
+                children: <TextSpan>[link],
+              );
+            } else {
+              textSpan = TextSpan(
+                style: effectiveTextStyle,
+                text: widget.data,
+              );
+            }
+            break;
+          default:
+            throw Exception(
+                'TrimMode type: ${widget.trimMode} is not supported');
+        }
+
+        return RichText(
+          textAlign: textAlign,
+          textDirection: textDirection,
+          softWrap: true,
+          //softWrap,
+          overflow: TextOverflow.clip,
+          //overflow,
+          textScaleFactor: textScaleFactor,
+          text: textSpan,
+        );
+      },
+    );
+    if (widget.semanticsLabel != null) {
+      result = Semantics(
+        textDirection: widget.textDirection,
+        label: widget.semanticsLabel,
+        child: ExcludeSemantics(
+          child: result,
+        ),
+      );
+    }
+    return result;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -575,7 +575,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.12"
+    version: "1.4.13"
   observable_ish:
     dependency: transitive
     description:


### PR DESCRIPTION
Only displays heading for 'about this bill' section if summary available

**Problem:**
- The 'about this bill' section can often be long and take up too much screen real-estate
- A bill doesn't always have an about section but the header always displays

**Solution:**
- Found a 'read more' widget and implemented for the about section
- Included a check to only include the about section if the text is available